### PR TITLE
Verify if model param has quotes, improve error messages

### DIFF
--- a/src/Commands/DataTableCommand.php
+++ b/src/Commands/DataTableCommand.php
@@ -82,13 +82,15 @@ class DataTableCommand extends Command
                 exit;
             }
 
-            $path = app_path('Http/Livewire/' . $tableName . '.php');
+            $create_at = 'Http/Livewire/' . $tableName . '.php';
+
+            $path = app_path($create_at);
 
             File::ensureDirectoryExists(app_path('Http/Livewire'));
 
             if (!File::exists($path) || $this->confirm('It seems <comment>' . $tableName . '</comment> already exists. Overwrite it?')) {
                 File::put($path, $stub);
-                $this->info('<comment>' . $tableName . '</comment> was successfully created at [<comment>' . $path . '</comment>]');
+                $this->info('<comment>' . $tableName . '</comment> was successfully created at [<comment>App/' . $create_at . '</comment>]');
             }
         }
     }

--- a/src/Commands/DataTableCommand.php
+++ b/src/Commands/DataTableCommand.php
@@ -26,7 +26,6 @@ class DataTableCommand extends Command
 
             $files = [
                 __DIR__ . '/../../resources/stubs/table.stub' => $stubsPath . '/table.stub',
-                __DIR__ . '/../../resources/stubs/table.collection.stub' => $stubsPath . '/table.collection.stub',
             ];
 
             foreach ($files as $from => $to) {


### PR DESCRIPTION
Verify if model param has quotes.
User needs to inform --model="App\Models\Resource"
Only --model=App\Models\Resource results in AppModelsResource.

Improved message output.